### PR TITLE
Document the strange behaviour of `--all`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: rust
+sudo: true
+cache:
+  timeout: 1024
+  directories:
+    - $HOME/.cargo
+
+rust: 1.31.0
+
+script:
+- cargo test
+- cargo test --all
+- cargo build && [ "$(target/debug/foo)" = "foo 0" ]
+- cargo build --all && [ "$(target/debug/foo)" = "foo 0" ]
+- cargo build --release && [ "$(target/release/foo)" = "foo 0" ]
+- cargo build --release --all && [ "$(target/release/foo)" = "foo 0" ]
+
+before_cache:
+- rm -rf $HOME/.cargo/registry

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+The crate `lib2` adds default `lib1` as dependencies for build, but enables
+feature `feature1` of `lib1` for test, documentation and benchmarks. This is
+a trick that `lib1` is added in both `dependencies` and `dev-dependencies` in
+[lib2/Cargo.toml](lib2/Cargo.toml).
+
+However, the cargo option `--all` leads to different behaviours. See how the
+[travis test](https://travis-ci.com/doitian/cargo-test) failed.
+
+## Test
+
+In test, the `feature1` should be enabled, so `lib2::foo()` must return 1, as
+asserted in the test case in [src/main.rs](src/main.rs).
+
+However, `cargo test --all` passes the test, while `cargo test` fails.
+
+## Build
+
+In build generated binary, the `feature1` should be disabled, so `lib2::foo()`
+must return 0 and the binary should print `foo 0`.
+
+However, the result also depends on whether the `--all` is added:
+
+```
+cargo build &>/dev/null && target/debug/foo
+# foo 0
+cargo build --all &>/dev/null && target/debug/foo
+# foo 1
+cargo build --release &>/dev/null && target/release/foo
+# foo 0
+cargo build --release --all &>/dev/null && target/release/foo
+# foo 1
+```
+
+## One Thing More
+
+If we change the top Cargo.toml as in #1，`feature1` is always enabled.


### PR DESCRIPTION
<div align=center markdown=1>
<a href="https://github.com/quake/cargo-test/blob/34a7696fc830191d82963c00ed83f84436e27eba/README.md">[RENDERED VIEW]</a>
</div>

